### PR TITLE
Check for newline in source and prefab files only

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -10,7 +10,9 @@
 
     <!-- Checks whether files end with a new line. -->
     <!-- See http://checkstyle.sourceforge.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+         <property name="fileExtensions" value="java,gradle,xml,txt,prefab"/>
+    </module>
 
     <!-- Checks that there are no tab characters ('\t') in the source code. -->
     <!-- See http://checkstyle.sourceforge.net/config_whitespace.html#FileTabCharacter -->


### PR DESCRIPTION
~~Under some circumstances~~ the eclipse CheckStyle plugin would also flag all png files and other resources for not ending with a new line character.
