### PR TITLE
add check for empty javadoc

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -53,6 +53,14 @@
         <property name="fileExtensions" value="java"/>
         <property name="message" value="Author tags are not allowed"/>
     </module>
+    
+    <!-- Disallow empty JavaDoc -->
+    <module name="RegexpMultiline">
+        <property name="severity" value="warning" />
+        <property name="format" value="(\/\*\*)(\s|\*)*(\*\/)" />
+        <property name="fileExtensions" value="java" />
+        <property name="message" value="Empty JavaDoc" />
+    </module>
 
     <module name="TreeWalker">
         <!-- Checks for Naming Conventions -->


### PR DESCRIPTION
The [JavadocStyle.checkEmptyJavadoc](http://checkstyle.sourceforge.net/config_javadoc.html#JavadocStyle) triggers on javadoc containing only  `@return ...` which is valid IMHO.
I think the used multiline regex is more flexible in our case.