### PR TITLE
Remove deprecated checkstyle property

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -198,9 +198,7 @@
         </module>
         <!-- Checks for the placement of left curly braces ('{') for code blocks. Default: eol -->
         <!-- See http://checkstyle.sourceforge.net/config_blocks.html#LeftCurly -->
-        <module name="LeftCurly">
-             <property name="maxLineLength" value="175"/>
-        </module>
+        <module name="LeftCurly"/>
         <!-- Checks for braces around code blocks. -->
         <!-- See http://checkstyle.sourceforge.net/config_blocks.html#NeedBraces -->
         <module name="NeedBraces"/>


### PR DESCRIPTION
In version 8.2 of checkstyle the property was completely removed. See MovingBlocks/Terasology#3113 for more informations.