### PR TITLE
hotfix PMD rule exclude

### DIFF
--- a/pmd/pmd.xml
+++ b/pmd/pmd.xml
@@ -20,7 +20,7 @@
   <!-- <rule ref="rulesets/java/junit.xml"/> -->
   <!-- <rule ref="rulesets/java/logging-jakarta-commons.xml"/> -->
   <rule ref="rulesets/java/logging-java.xml">
-      <exclude name="GuardLogStatement"/>
+      <exclude name="GuardLogStatementJavaUtil"/>
   </rule>
   <rule ref="rulesets/java/migrating.xml"/>
   <!-- <rule ref="rulesets/java/naming.xml"/> -->


### PR DESCRIPTION
idk, what happens with pmd versions....
Return old value of exlude, then work and fix master.

This value marked as deprecated.
We must use other ruleset for all rules from this ruleset.

Incoming many changes with rulesets in next PMD's major.