### PR TITLE
Move LineLength out to be its own top level element

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -4,6 +4,14 @@
           "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
+    <!-- Checks for Size Violations -->
+    <!-- See http://checkstyle.sourceforge.net/config_sizes.html -->
+    <!-- ************************** -->
+    <module name="LineLength">
+        <property name="severity" value="warning"/>
+        <property name="max" value="175"/>
+    </module>
+
     <module name="SuppressionFilter">
         <property name="file" value="${samedir}/suppressions.xml"/>
     </module>
@@ -121,13 +129,6 @@
         <!-- See http://checkstyle.sourceforge.net/config_imports.html#IllegalImport -->
         <module name="IllegalImport"/>
 
-        <!-- Checks for Size Violations -->
-        <!-- See http://checkstyle.sourceforge.net/config_sizes.html -->
-        <!-- ************************** -->
-        <module name="LineLength">        
-            <property name="severity" value="warning"/>
-            <property name="max" value="175"/>
-        </module>
         <!-- Checks for the number of types declared at the outer (or root) level in a file. -->
         <module name="OuterTypeNumber"/>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.3.1
+version=1.3.2


### PR DESCRIPTION
Another tiny fix - was getting this error with latest IntelliJ while testing https://github.com/Terasology/Sample/pull/112, unsure if just related to the IntelliJ Checkstyle plugin upgrading or something else?

Zip already published to Artifactory, but need to bump dependent projects accordingly.