### PR TITLE
feat: Update Checkstyle rules to allow for shortened SPDX license header

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -39,7 +39,8 @@
     <!-- Checks that a source file begins with a specified header. --> 
     <module name="RegexpHeader">
         <property name="severity" value="warning"/>
-        <property name="header" value="/*\n * Copyright 20\d\d MovingBlocks\n *\n * Licensed under the Apache License, Version 2.0"/>
+        <property name="header" value="(/*\n * Copyright 20\d\d MovingBlocks\n *\n * Licensed under the Apache License, Version 2.0)|(// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0)"/>
         <property name="fileExtensions" value="java"/>
     </module>
   

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -39,7 +39,7 @@
     <!-- Checks that a source file begins with a specified header. --> 
     <module name="RegexpHeader">
         <property name="severity" value="warning"/>
-        <property name="header" value="(/*\n * Copyright 20\d\d MovingBlocks\n *\n * Licensed under the Apache License, Version 2.0)|(// Copyright 2020 The Terasology Foundation\n// SPDX-License-Identifier: Apache-2.0)"/>
+        <property name="header" value="(/*\n * Copyright 20\d\d MovingBlocks\n *\n * Licensed under the Apache License, Version 2.0)|(// Copyright 20\d\d The Terasology Foundation\n// SPDX-License-Identifier: Apache-2.0)"/>
         <property name="fileExtensions" value="java"/>
     </module>
   

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -39,8 +39,7 @@
     <!-- Checks that a source file begins with a specified header. --> 
     <module name="RegexpHeader">
         <property name="severity" value="warning"/>
-        <property name="header" value="(/*\n * Copyright 20\d\d MovingBlocks\n *\n * Licensed under the Apache License, Version 2.0)|(// Copyright 2020 The Terasology Foundation
-// SPDX-License-Identifier: Apache-2.0)"/>
+        <property name="header" value="(/*\n * Copyright 20\d\d MovingBlocks\n *\n * Licensed under the Apache License, Version 2.0)|(// Copyright 2020 The Terasology Foundation\n// SPDX-License-Identifier: Apache-2.0)"/>
         <property name="fileExtensions" value="java"/>
     </module>
   


### PR DESCRIPTION
With this simple regex change Checkstyle will accept both the old and new license header style:

**new**
```
// Copyright 2020 The Terasology Foundation
// SPDX-License-Identifier: Apache-2.0
```

**old**
```
/*
 * Copyright 2013 MovingBlocks
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *      http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
```
