### PR TITLE
fix(checkstyle): license header regex

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -39,7 +39,7 @@
     <!-- Checks that a source file begins with a specified header. --> 
     <module name="RegexpHeader">
         <property name="severity" value="warning"/>
-        <property name="header" value="(/*\n * Copyright 20\d\d MovingBlocks\n *\n * Licensed under the Apache License, Version 2.0)|(// Copyright 20\d\d The Terasology Foundation\n// SPDX-License-Identifier: Apache-2.0)"/>
+        <property name="header" value="// Copyright 20\d\d The Terasology Foundation\n// SPDX-License-Identifier: Apache-2.0"/>
         <property name="fileExtensions" value="java"/>
     </module>
   


### PR DESCRIPTION
As mentioned in a comment on #13 

* `RegexpHeaderCheck` is not able to work with multiline regex expressions. It splits on every `\n` which is why alternation across multiple lines is not possible.
* `RegexpCheck` is able to work with multiline regex expressions and can also act like `RegexpHeaderCheck` by using `\A` for the file beginning but for some reason doesn't identify alternation correctly, so it tries to match the whole expression (including the `|`).

This PR removes the old license header regex to enable a new 1.5.1 release that will only check for the new regex.

Closes #13 
 