### PR TITLE
feat: Exclude JMH benchmarks from SpotBugs

### DIFF
--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -25,4 +25,13 @@
     <Match>
         <Package name="~org\.terasology\.protobuf.*" />
     </Match>
+    <Match>
+        <Class name="~.*jmhTest"/>
+    </Match>
+    <Match>
+        <Class name="~.*jmhType.*"/>
+    </Match>
+    <Match>
+        <Bug pattern="JMH_BENCHMARK_METHOD_FOUND"/>
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Avoids the 12k warnings that snuck in with https://github.com/MovingBlocks/Terasology/pull/4401. Probably would even cover the same elsewhere like in modules should we add such tests there eventually.