### PR TITLE
checkstyle: lower severity of some rules

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -269,7 +269,7 @@
         <module name="ParameterAssignment"/>
         <!-- Checks if any class or object member explicitly initialized to default for its type value. -->
         <module name="ExplicitInitialization">
-            <property name="severity" value="warning"/>
+           <property name="severity" value="ignore"/> <!-- 'ignore' because we often want to be explicit about initializations and belive the performance penalty is negligible -->
         </module>
         <!-- Check that the default is after all the cases in a switch statement. -->
         <module name="DefaultComesLast"/>

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -89,6 +89,7 @@
         <!-- Unfortunately this module is too inclusive - static final fields are not necessarily constants! -->
         <module name="ConstantName">
             <property name="format" value="^([A-Z][A-Z0-9]*(_[A-Z0-9]+)*|logger)$"/>
+            <property name="severity" value="info">
         </module>
         <!-- local, final variables, including catch parameters : ^[a-z][a-zA-Z0-9]*$ -->
         <module name="LocalFinalVariableName"/>


### PR DESCRIPTION
As discussed in https://github.com/MovingBlocks/Terasology/pull/4702

- checkstyle: lower severity of ConstantName to INFO
- checkstyle: lower severity of ExplicitInitialization to IGNORE
