### PR TITLE
chore: remove deprecation warnings for pmd-7.0

### DIFF
--- a/pmd/pmd.xml
+++ b/pmd/pmd.xml
@@ -38,10 +38,7 @@
   <rule ref="category/java/design.xml/CollapsibleIfStatements" />
   <rule ref="category/java/design.xml/SimplifiedTernary" />
 <!--  inline <rule ref="rulesets/java/braces.xml"/>-->
-  <rule ref="category/java/codestyle.xml/ForLoopsMustUseBraces" />
-  <rule ref="category/java/codestyle.xml/IfElseStmtsMustUseBraces" />
-  <rule ref="category/java/codestyle.xml/IfStmtsMustUseBraces" />
-  <rule ref="category/java/codestyle.xml/WhileLoopsMustUseBraces" />
+  <rule ref="category/java/codestyle.xml/ControlStatementBraces" />
 <!--  <rule ref="rulesets/java/clone.xml"/>-->
 <!--  <rule ref="rulesets/java/finalizers.xml"/>-->
 <!--  <rule ref="rulesets/java/logging-java.xml">-->

--- a/pmd/pmd.xml
+++ b/pmd/pmd.xml
@@ -40,11 +40,53 @@
 <!--  inline <rule ref="rulesets/java/braces.xml"/>-->
   <rule ref="category/java/codestyle.xml/ControlStatementBraces" />
 <!--  <rule ref="rulesets/java/clone.xml"/>-->
-<!--  <rule ref="rulesets/java/finalizers.xml"/>-->
+  <rule ref="category/java/errorprone.xml/CloneMethodMustBePublic" />
+  <rule ref="category/java/errorprone.xml/CloneMethodMustImplementCloneable" />
+  <rule ref="category/java/errorprone.xml/CloneMethodReturnTypeMustMatchClassName" />
+  <rule ref="category/java/errorprone.xml/CloneThrowsCloneNotSupportedException" />
+  <rule ref="category/java/errorprone.xml/ProperCloneImplementation" />
+<!-- <rule ref="rulesets/java/finalizers.xml"/>-->
+  <rule ref="category/java/errorprone.xml/AvoidCallingFinalize" />
+  <rule ref="category/java/errorprone.xml/EmptyFinalizer" />
+  <rule ref="category/java/errorprone.xml/FinalizeDoesNotCallSuperFinalize" />
+  <rule ref="category/java/errorprone.xml/FinalizeOnlyCallsSuperFinalize" />
+  <rule ref="category/java/errorprone.xml/FinalizeOverloaded" />
+  <rule ref="category/java/errorprone.xml/FinalizeShouldBeProtected" />
 <!--  <rule ref="rulesets/java/logging-java.xml">-->
 <!--      <exclude name="GuardLogStatementJavaUtil"/>-->
 <!--  </rule>-->
+  <rule ref="category/java/errorprone.xml/InvalidSlf4jMessageFormat" />
+  <rule ref="category/java/errorprone.xml/LoggerIsNotStaticFinal" />
+  <rule ref="category/java/errorprone.xml/MoreThanOneLogger" />
+
+  <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace" />
+  <!-- GuardLogStatementJavaUtil has been merged into GuardLogStatement -->
+  <rule ref="category/java/bestpractices.xml/GuardLogStatement" name="GuardLogStatementJavaUtil" />
+  <rule ref="category/java/bestpractices.xml/SystemPrintln" />
 <!--  <rule ref="rulesets/java/migrating.xml"/>-->
+  <rule ref="category/java/errorprone.xml/AvoidAssertAsIdentifier" />
+  <rule ref="category/java/errorprone.xml/AvoidEnumAsIdentifier" />
+
+  <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach" />
+  <rule ref="category/java/bestpractices.xml/JUnit4SuitesShouldUseSuiteAnnotation" />
+  <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseAfterAnnotation" />
+  <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseBeforeAnnotation" />
+  <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseTestAnnotation" />
+  <rule ref="category/java/bestpractices.xml/JUnitUseExpected" />
+  <rule ref="category/java/bestpractices.xml/ReplaceEnumerationWithIterator" />
+  <rule ref="category/java/bestpractices.xml/ReplaceHashtableWithMap" />
+  <rule ref="category/java/bestpractices.xml/ReplaceVectorWithList" />
+
+  <rule ref="category/java/performance.xml/ByteInstantiation" />
+  <rule ref="category/java/performance.xml/IntegerInstantiation" />
+  <rule ref="category/java/performance.xml/LongInstantiation" />
+  <rule ref="category/java/performance.xml/ShortInstantiation" />
 <!--  <rule ref="rulesets/java/sunsecure.xml"/>-->
+  <rule ref="category/java/bestpractices.xml/ArrayIsStoredDirectly" />
+  <rule ref="category/java/bestpractices.xml/MethodReturnsInternalArray" />
 <!--  <rule ref="rulesets/java/unusedcode.xml"/>-->
+  <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />
+  <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />
+  <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
+  <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
 </ruleset>

--- a/pmd/pmd.xml
+++ b/pmd/pmd.xml
@@ -39,30 +39,31 @@
   <rule ref="category/java/design.xml/SimplifiedTernary" />
 <!--  inline <rule ref="rulesets/java/braces.xml"/>-->
   <rule ref="category/java/codestyle.xml/ControlStatementBraces" />
-<!--  <rule ref="rulesets/java/clone.xml"/>-->
+<!-- inline  <rule ref="rulesets/java/clone.xml"/>-->
   <rule ref="category/java/errorprone.xml/CloneMethodMustBePublic" />
   <rule ref="category/java/errorprone.xml/CloneMethodMustImplementCloneable" />
   <rule ref="category/java/errorprone.xml/CloneMethodReturnTypeMustMatchClassName" />
   <rule ref="category/java/errorprone.xml/CloneThrowsCloneNotSupportedException" />
   <rule ref="category/java/errorprone.xml/ProperCloneImplementation" />
-<!-- <rule ref="rulesets/java/finalizers.xml"/>-->
+<!-- inline <rule ref="rulesets/java/finalizers.xml"/>-->
   <rule ref="category/java/errorprone.xml/AvoidCallingFinalize" />
   <rule ref="category/java/errorprone.xml/EmptyFinalizer" />
   <rule ref="category/java/errorprone.xml/FinalizeDoesNotCallSuperFinalize" />
   <rule ref="category/java/errorprone.xml/FinalizeOnlyCallsSuperFinalize" />
   <rule ref="category/java/errorprone.xml/FinalizeOverloaded" />
   <rule ref="category/java/errorprone.xml/FinalizeShouldBeProtected" />
-<!--  <rule ref="rulesets/java/logging-java.xml">-->
+<!-- inline <rule ref="rulesets/java/logging-java.xml">-->
 <!--      <exclude name="GuardLogStatementJavaUtil"/>-->
 <!--  </rule>-->
   <rule ref="category/java/errorprone.xml/InvalidSlf4jMessageFormat" />
   <rule ref="category/java/errorprone.xml/MoreThanOneLogger" />
+  <rule ref="category/java/errorprone.xml/ProperLogger" />
 
   <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace" />
   <!-- GuardLogStatementJavaUtil has been merged into GuardLogStatement -->
   <rule ref="category/java/bestpractices.xml/GuardLogStatement" name="GuardLogStatementJavaUtil" />
   <rule ref="category/java/bestpractices.xml/SystemPrintln" />
-<!--  <rule ref="rulesets/java/migrating.xml"/>-->
+<!-- inline <rule ref="rulesets/java/migrating.xml"/>-->
   <rule ref="category/java/errorprone.xml/AvoidAssertAsIdentifier" />
   <rule ref="category/java/errorprone.xml/AvoidEnumAsIdentifier" />
 
@@ -80,10 +81,10 @@
   <rule ref="category/java/performance.xml/IntegerInstantiation" />
   <rule ref="category/java/performance.xml/LongInstantiation" />
   <rule ref="category/java/performance.xml/ShortInstantiation" />
-<!--  <rule ref="rulesets/java/sunsecure.xml"/>-->
+<!-- inline <rule ref="rulesets/java/sunsecure.xml"/>-->
   <rule ref="category/java/bestpractices.xml/ArrayIsStoredDirectly" />
   <rule ref="category/java/bestpractices.xml/MethodReturnsInternalArray" />
-<!--  <rule ref="rulesets/java/unusedcode.xml"/>-->
+<!-- inline <rule ref="rulesets/java/unusedcode.xml"/>-->
   <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />
   <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />
   <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />

--- a/pmd/pmd.xml
+++ b/pmd/pmd.xml
@@ -8,46 +8,46 @@
   </description>
   <exclude-pattern>.*/org.terasology.protobuf/.*</exclude-pattern>
 <!-- inline <rule ref="rulesets/java/basic.xml"/>  -->
-  <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop" deprecated="true" />
-  <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor" deprecated="true" />
-  <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators" deprecated="true" />
-  <rule ref="category/java/errorprone.xml/AvoidUsingOctalValues" deprecated="true" />
-  <rule ref="category/java/errorprone.xml/BrokenNullCheck" deprecated="true" />
-  <rule ref="category/java/errorprone.xml/CheckSkipResult" deprecated="true" />
-  <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray" deprecated="true" />
-  <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices" deprecated="true" />
-  <rule ref="category/java/errorprone.xml/JumbledIncrementer" deprecated="true" />
-  <rule ref="category/java/errorprone.xml/MisplacedNullCheck" deprecated="true" />
-  <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode" deprecated="true" />
-  <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock" deprecated="true" />
-  <rule ref="category/java/errorprone.xml/UnconditionalIfStatement" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop" />
+  <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor" />
+  <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators" />
+  <rule ref="category/java/errorprone.xml/AvoidUsingOctalValues"  />
+  <rule ref="category/java/errorprone.xml/BrokenNullCheck" />
+  <rule ref="category/java/errorprone.xml/CheckSkipResult" />
+  <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray" />
+  <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices" />
+  <rule ref="category/java/errorprone.xml/JumbledIncrementer" />
+  <rule ref="category/java/errorprone.xml/MisplacedNullCheck" />
+  <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode" />
+  <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock" />
+  <rule ref="category/java/errorprone.xml/UnconditionalIfStatement" />
 
-  <rule ref="category/java/multithreading.xml/AvoidThreadGroup" deprecated="true" />
-  <rule ref="category/java/multithreading.xml/DontCallThreadRun" deprecated="true" />
-  <rule ref="category/java/multithreading.xml/DoubleCheckedLocking" deprecated="true" />
+  <rule ref="category/java/multithreading.xml/AvoidThreadGroup" />
+  <rule ref="category/java/multithreading.xml/DontCallThreadRun" />
+  <rule ref="category/java/multithreading.xml/DoubleCheckedLocking" />
 
-  <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP" deprecated="true" />
-  <rule ref="category/java/bestpractices.xml/CheckResultSet" deprecated="true" />
+  <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP" />
+  <rule ref="category/java/bestpractices.xml/CheckResultSet" />
 
-  <rule ref="category/java/codestyle.xml/ExtendsObject" deprecated="true" />
-  <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop" deprecated="true" />
+  <rule ref="category/java/codestyle.xml/ExtendsObject" />
+  <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop" />
 
-  <rule ref="category/java/performance.xml/BigIntegerInstantiation" deprecated="true" />
-  <rule ref="category/java/performance.xml/BooleanInstantiation" deprecated="true" />
+  <rule ref="category/java/performance.xml/BigIntegerInstantiation" />
+  <rule ref="category/java/performance.xml/BooleanInstantiation" />
 
-  <rule ref="category/java/design.xml/CollapsibleIfStatements" deprecated="true" />
-  <rule ref="category/java/design.xml/SimplifiedTernary" deprecated="true" />
+  <rule ref="category/java/design.xml/CollapsibleIfStatements" />
+  <rule ref="category/java/design.xml/SimplifiedTernary" />
 <!--  inline <rule ref="rulesets/java/braces.xml"/>-->
-  <rule ref="category/java/codestyle.xml/ForLoopsMustUseBraces" deprecated="true" />
-  <rule ref="category/java/codestyle.xml/IfElseStmtsMustUseBraces" deprecated="true" />
-  <rule ref="category/java/codestyle.xml/IfStmtsMustUseBraces" deprecated="true" />
-  <rule ref="category/java/codestyle.xml/WhileLoopsMustUseBraces" deprecated="true" />
-  <rule ref="rulesets/java/clone.xml"/>
-  <rule ref="rulesets/java/finalizers.xml"/>
-  <rule ref="rulesets/java/logging-java.xml">
-      <exclude name="GuardLogStatementJavaUtil"/>
-  </rule>
-  <rule ref="rulesets/java/migrating.xml"/>
-  <rule ref="rulesets/java/sunsecure.xml"/>
-  <rule ref="rulesets/java/unusedcode.xml"/>
+  <rule ref="category/java/codestyle.xml/ForLoopsMustUseBraces" />
+  <rule ref="category/java/codestyle.xml/IfElseStmtsMustUseBraces" />
+  <rule ref="category/java/codestyle.xml/IfStmtsMustUseBraces" />
+  <rule ref="category/java/codestyle.xml/WhileLoopsMustUseBraces" />
+<!--  <rule ref="rulesets/java/clone.xml"/>-->
+<!--  <rule ref="rulesets/java/finalizers.xml"/>-->
+<!--  <rule ref="rulesets/java/logging-java.xml">-->
+<!--      <exclude name="GuardLogStatementJavaUtil"/>-->
+<!--  </rule>-->
+<!--  <rule ref="rulesets/java/migrating.xml"/>-->
+<!--  <rule ref="rulesets/java/sunsecure.xml"/>-->
+<!--  <rule ref="rulesets/java/unusedcode.xml"/>-->
 </ruleset>

--- a/pmd/pmd.xml
+++ b/pmd/pmd.xml
@@ -10,24 +10,11 @@
   <rule ref="rulesets/java/basic.xml"/>
   <rule ref="rulesets/java/braces.xml"/>
   <rule ref="rulesets/java/clone.xml"/>
-  <!-- <rule ref="rulesets/java/codesize.xml"/> -->
-  <!-- <rule ref="rulesets/java/controversial.xml"/> -->
-  <!-- <rule ref="rulesets/java/coupling.xml"/> -->
-  <!-- <rule ref="rulesets/java/design.xml"/> -->
   <rule ref="rulesets/java/finalizers.xml"/>
-  <!-- rule ref="rulesets/java/imports.xml"/> -->
-  <!-- <rule ref="rulesets/java/javabeans.xml"/> -->
-  <!-- <rule ref="rulesets/java/junit.xml"/> -->
-  <!-- <rule ref="rulesets/java/logging-jakarta-commons.xml"/> -->
   <rule ref="rulesets/java/logging-java.xml">
       <exclude name="GuardLogStatementJavaUtil"/>
   </rule>
   <rule ref="rulesets/java/migrating.xml"/>
-  <!-- <rule ref="rulesets/java/naming.xml"/> -->
-  <!-- <rule ref="rulesets/java/optimizations.xml"/> -->
-  <!-- <rule ref="rulesets/java/strictexception.xml"/> -->
-  <!-- <rule ref="rulesets/java/strings.xml"/> -->
   <rule ref="rulesets/java/sunsecure.xml"/>
-  <!-- <rule ref="rulesets/java/typeresolution.xml"/> -->
   <rule ref="rulesets/java/unusedcode.xml"/>
 </ruleset>

--- a/pmd/pmd.xml
+++ b/pmd/pmd.xml
@@ -56,7 +56,6 @@
 <!--      <exclude name="GuardLogStatementJavaUtil"/>-->
 <!--  </rule>-->
   <rule ref="category/java/errorprone.xml/InvalidSlf4jMessageFormat" />
-  <rule ref="category/java/errorprone.xml/LoggerIsNotStaticFinal" />
   <rule ref="category/java/errorprone.xml/MoreThanOneLogger" />
 
   <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace" />

--- a/pmd/pmd.xml
+++ b/pmd/pmd.xml
@@ -7,8 +7,41 @@
       Terasology PMD ruleset
   </description>
   <exclude-pattern>.*/org.terasology.protobuf/.*</exclude-pattern>
-  <rule ref="rulesets/java/basic.xml"/>
-  <rule ref="rulesets/java/braces.xml"/>
+<!-- inline <rule ref="rulesets/java/basic.xml"/>  -->
+  <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/AvoidUsingOctalValues" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/BrokenNullCheck" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/CheckSkipResult" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/JumbledIncrementer" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/MisplacedNullCheck" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock" deprecated="true" />
+  <rule ref="category/java/errorprone.xml/UnconditionalIfStatement" deprecated="true" />
+
+  <rule ref="category/java/multithreading.xml/AvoidThreadGroup" deprecated="true" />
+  <rule ref="category/java/multithreading.xml/DontCallThreadRun" deprecated="true" />
+  <rule ref="category/java/multithreading.xml/DoubleCheckedLocking" deprecated="true" />
+
+  <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP" deprecated="true" />
+  <rule ref="category/java/bestpractices.xml/CheckResultSet" deprecated="true" />
+
+  <rule ref="category/java/codestyle.xml/ExtendsObject" deprecated="true" />
+  <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop" deprecated="true" />
+
+  <rule ref="category/java/performance.xml/BigIntegerInstantiation" deprecated="true" />
+  <rule ref="category/java/performance.xml/BooleanInstantiation" deprecated="true" />
+
+  <rule ref="category/java/design.xml/CollapsibleIfStatements" deprecated="true" />
+  <rule ref="category/java/design.xml/SimplifiedTernary" deprecated="true" />
+<!--  inline <rule ref="rulesets/java/braces.xml"/>-->
+  <rule ref="category/java/codestyle.xml/ForLoopsMustUseBraces" deprecated="true" />
+  <rule ref="category/java/codestyle.xml/IfElseStmtsMustUseBraces" deprecated="true" />
+  <rule ref="category/java/codestyle.xml/IfStmtsMustUseBraces" deprecated="true" />
+  <rule ref="category/java/codestyle.xml/WhileLoopsMustUseBraces" deprecated="true" />
   <rule ref="rulesets/java/clone.xml"/>
   <rule ref="rulesets/java/finalizers.xml"/>
   <rule ref="rulesets/java/logging-java.xml">


### PR DESCRIPTION
inline the rules, without change. adapt the ones moved into another one, remove one not any more supported. these actions have dedicated commits to make it easer to follow.
