### PR TITLE
config: remove checkstyle HiddenField rule

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -222,13 +222,6 @@
         <module name="EmptyStatement"/>
         <!-- Checks that classes that override equals() also override hashCode(). -->
         <module name="EqualsHashCode"/>
-        <!-- Checks that a local variable or a parameter does not shadow a field that is defined in the same class. -->
-        <module name="HiddenField">
-            <property name="severity" value="info"/>
-            <property name="ignoreConstructorParameter" value="true"/>
-            <property name="ignoreSetter" value="true"/>
-            <property name="setterCanReturnItsClass" value="true"/>
-        </module>
         <!-- Checks for assignments in subexpressions. -->
         <module name="InnerAssignment"/>
         <!-- Check for ensuring that for loop control variables are not modified inside the for block. -->


### PR DESCRIPTION
The checkstyle `HiddenField` rule "checks that a local variable or a parameter does not shadow a field that is defined in the same class" [[1]](https://checkstyle.sourceforge.io/checks/coding/hiddenfield.html).

While "it is possible to configure the check to ignore all property setter methods" of a specific format, we often "combine" setters or name methods differently. "Fixing" associated findings by prefixing/renaming the parameters often makes the code harder to understand.

Findings that are not related to constructors or getters/setters are rarely seen in our code base, so @BenjaminAmos (BSA) @skaldarnar and I (@jdrueckert / Niruandaleth) decided to drop this rule to reduce noise as it doesn't bring us any benefit and instead rather fosters confusion.

[1] - https://checkstyle.sourceforge.io/checks/coding/hiddenfield.html